### PR TITLE
Fixed cython version.

### DIFF
--- a/.github/workflows/pypi-package-deployment.yml
+++ b/.github/workflows/pypi-package-deployment.yml
@@ -34,7 +34,7 @@ jobs:
     uses: 'joint-probability-trees/jpt-dev/.github/workflows/reusable-test-and-build.yml@main'
     with:
       version: "${{ inputs.version || github.ref_name }}"
-      python-versions: "cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311"
+      python-versions: "cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312"
 
   # --------------------------------------------------------------------------------------------------------------------
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-Cython
+Cython<3.0.3
 ddt
 jupyter
 auditwheel


### PR DESCRIPTION
Cython > 3.0.2 will break the package since something changed regarding the cythonize call. I could not pinpoint whats the problem yet.